### PR TITLE
`Cronitor.configure` to set default token

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ end
 
 ```
 # .env
-CRONITOR_TOKEN = 'token'
+CRONITOR_TOKEN: token
 ```
 
 ### Creating a Monitor

--- a/README.md
+++ b/README.md
@@ -25,6 +25,28 @@ Or install it yourself as:
 
 ## Usage
 
+
+### Configure
+
+You need to set Cronitor Token in order to create a monitor
+
+#### Using configure
+
+```ruby
+require 'cronitor'
+
+Cronitor.configure do |cronitor|
+  cronitor.default_token = 'token' # default token to be re-used by cronitor
+end
+````
+
+#### Using ENV
+
+```
+# .env
+CRONITOR_TOKEN = 'token'
+```
+
 ### Creating a Monitor
 
 A Cronitor monitor (hereafter referred to only as a monitor for brevity) is created if it does not already exist, and its ID returned.
@@ -56,7 +78,7 @@ monitor_options = {
   note: 'A human-friendly description of this monitor'
 }
 
-# The token parameter is optional; if omittted, ENV['CRONITOR_TOKEN'] will be used
+# The token parameter is optional; if omittted, ENV['CRONITOR_TOKEN'] will be used if not configured
 my_monitor = Cronitor.new token: 'api_token', opts: monitor_options
 ```
 

--- a/lib/cronitor.rb
+++ b/lib/cronitor.rb
@@ -7,16 +7,20 @@ require 'net/http'
 require 'uri'
 
 class Cronitor
-  attr_accessor :token, :opts, :code
+  attr_accessor :opts, :code
   API_URL = 'https://cronitor.io/v3'
   PING_URL = 'https://cronitor.link'
 
+  class << self
+    attr_accessor :token
+  end
+
   def initialize(token: ENV['CRONITOR_TOKEN'], opts: {}, code: nil)
-    @token = token
+    self.class.token ||= token
     @opts = opts
     @code = code
 
-    if @token.nil? && @code.nil?
+    if self.class.token.nil? && @code.nil?
       raise(
         Cronitor::Error,
         'Either a Cronitor API token or an existing monitor code must be ' \
@@ -46,7 +50,7 @@ class Cronitor
     http.use_ssl = uri.scheme == 'https'
 
     request = Net::HTTP::Post.new uri.path, default_headers
-    request.basic_auth token, nil
+    request.basic_auth self.class.token, nil
     request.content_type = 'application/json'
     request.body = JSON.generate opts
 
@@ -62,7 +66,7 @@ class Cronitor
     http.use_ssl = uri.scheme == 'https'
 
     request = Net::HTTP::Get.new uri.path, default_headers
-    request.basic_auth token, nil
+    request.basic_auth self.class.token, nil
 
     response = http.request request
 

--- a/lib/cronitor.rb
+++ b/lib/cronitor.rb
@@ -54,7 +54,7 @@ class Cronitor
     http.use_ssl = uri.scheme == 'https'
 
     request = Net::HTTP::Post.new uri.path, default_headers
-    request.basic_auth @token, nil
+    request.basic_auth token, nil
     request.content_type = 'application/json'
     request.body = JSON.generate opts
 
@@ -70,7 +70,7 @@ class Cronitor
     http.use_ssl = uri.scheme == 'https'
 
     request = Net::HTTP::Get.new uri.path, default_headers
-    request.basic_auth @token, nil
+    request.basic_auth token, nil
 
     response = http.request request
 

--- a/spec/cronitor_spec.rb
+++ b/spec/cronitor_spec.rb
@@ -7,6 +7,31 @@ RSpec.describe Cronitor do
   let(:monitor_options) { nil }
 
   before(:all) { ENV.delete('CRONITOR_TOKEN') }
+  before(:each) { described_class.token = nil }
+
+  describe '.token' do
+    before do
+      described_class.token = token
+      allow_any_instance_of(described_class).to receive(:create)
+    end
+
+    it 'set token on class' do
+      expect(described_class.token).to eq(token)
+    end
+
+    it 'reuse class token' do
+      expect { subject }.not_to raise_error
+    end
+
+    context 'with no class token' do
+      let(:token) { nil }
+
+      it 'raise' do
+        expect { subject }.to raise_error Cronitor::Error, 'Either a Cronitor API token or an existing monitor code must be ' \
+          'provided'
+      end
+    end
+  end
 
   it 'has a version number' do
     expect(Cronitor::VERSION).not_to be nil
@@ -20,7 +45,7 @@ RSpec.describe Cronitor do
     end
 
     it 'has the specified API token' do
-      expect(monitor.token).to eq '1234'
+      expect(monitor.class.token).to eq '1234'
     end
 
     it 'has the specified options' do
@@ -54,7 +79,7 @@ RSpec.describe Cronitor do
         after { ENV.delete('CRONITOR_TOKEN') }
 
         it 'uses the token from ENV' do
-          expect(monitor.token).to eql(token)
+          expect(monitor.class.token).to eql(token)
         end
       end
 

--- a/spec/cronitor_spec.rb
+++ b/spec/cronitor_spec.rb
@@ -7,29 +7,39 @@ RSpec.describe Cronitor do
   let(:monitor_options) { nil }
 
   before(:all) { ENV.delete('CRONITOR_TOKEN') }
-  before(:each) { described_class.token = nil }
+  before(:each) { described_class.default_token = nil }
 
-  describe '.token' do
+  describe '.default_token' do
     before do
-      described_class.token = token
       allow_any_instance_of(described_class).to receive(:create)
     end
 
     it 'set token on class' do
-      expect(described_class.token).to eq(token)
+      described_class.default_token = token
+      expect(described_class.default_token).to eq(token)
     end
 
     it 'reuse class token' do
+      described_class.default_token = token
       expect { subject }.not_to raise_error
     end
 
     context 'with no class token' do
-      let(:token) { nil }
-
       it 'raise' do
         expect { subject }.to raise_error Cronitor::Error, 'Either a Cronitor API token or an existing monitor code must be ' \
           'provided'
       end
+    end
+  end
+
+  describe '.configure' do
+    before do
+      allow_any_instance_of(described_class).to receive(:create)
+    end
+
+    it 'configure' do
+      described_class.configure { |cronitor| cronitor.default_token = token } 
+      expect(described_class.default_token).to eq(token)
     end
   end
 
@@ -45,7 +55,7 @@ RSpec.describe Cronitor do
     end
 
     it 'has the specified API token' do
-      expect(monitor.class.token).to eq '1234'
+      expect(monitor.token).to eq '1234'
     end
 
     it 'has the specified options' do
@@ -79,7 +89,7 @@ RSpec.describe Cronitor do
         after { ENV.delete('CRONITOR_TOKEN') }
 
         it 'uses the token from ENV' do
-          expect(monitor.class.token).to eql(token)
+          expect(monitor.token).to eql(token)
         end
       end
 


### PR DESCRIPTION
Accept Cronitor API Token to be set in an initializer (vs `ENV['CRONITOR_TOKEN']`)
````
# config/initializers/cronitor.rb
Cronitor.configure { |cronitor| cronitor.default_token = Rails.application.credentials.CRONITOR_TOKEN }
````