### PR TITLE
Tighten up linting & add testing on Ruby 3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,30 +11,42 @@ on:
 
 jobs:
   lint:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - '2.7'
+          - '3.0'
 
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby 2.7
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.x
-      - name: Rubocop Linter Action
-        uses: andrewmcodes/rubocop-linter-action@v3.1.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Run Rubocop
+        run: bundle exec rake rubocop
 
   spec:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - '2.7'
+          - '3.0'
 
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby 2.7
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.x
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
       - name: Build and test with Rake
         run: |
           gem install bundler

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,9 @@ require:
   - rubocop-rake
   - rubocop-rspec
 
+AllCops:
+  NewCops: enable
+
 Metrics/AbcSize:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,8 @@
 ---
+require:
+  - rubocop-rake
+  - rubocop-rspec
+
 Metrics/AbcSize:
   Enabled: false
 

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,13 @@
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 require 'bump/tasks'
+require 'rubocop/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
+
+RuboCop::RakeTask.new do |task|
+  task.requires << 'rubocop-rake'
+  task.requires << 'rubocop-rspec'
+end
 
 task default: :spec

--- a/cronitor.gemspec
+++ b/cronitor.gemspec
@@ -25,6 +25,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry', '~> 0.10'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 3.3'
+  spec.add_development_dependency 'rubocop', '~> 1.8'
+  spec.add_development_dependency 'rubocop-rake', '~> 0.5.1'
+  spec.add_development_dependency 'rubocop-rspec', '~> 2.1'
   spec.add_development_dependency 'sinatra', '~> 2.0'
   spec.add_development_dependency 'webmock', '~> 3.1'
 end


### PR DESCRIPTION
I noticed we've been using an old way of running the RuboCop linting, and also not testing on Ruby 3, so this spruces all that up.