### PR TITLE
Fix for "undefined method `+` for nil:NilClass" for "params[:retry_count]"

### DIFF
--- a/lib/cronitor/monitor.rb
+++ b/lib/cronitor/monitor.rb
@@ -117,7 +117,7 @@ module Cronitor
 
         # apply a backoff before sending the next ping
         sleep(retry_count * 1.5 * rand)
-        ping(params.merge(retry_count: params[:retry_count] + 1))
+        ping(params.merge(retry_count: retry_count + 1))
       end
     end
 


### PR DESCRIPTION
I'm seeing this in our logs:

```
undefined method `+' for nil:NilClass
```
with this (partial) stack trace:
```
/bundle/ruby/2.5.0/gems/cronitor-4.1.0/lib/cronitor/monitor.rb:120:in `rescue in ping'; 
/bundle/ruby/2.5.0/gems/cronitor-4.1.0/lib/cronitor/monitor.rb:88:in `ping';
```

It looks like we probably want to use `retry_count` instead of `params[:retry_count]` since you already did a `nil` check earlier in the `ping` method:
https://github.com/jalessio/cronitor-ruby/blob/80ed374c8526d4d6da38f1dbd569f714c683910a/lib/cronitor/monitor.rb#L82
```
      retry_count = params[:retry_count] || 0
```