### PR TITLE
Clean up and add configurability

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ a deployment or build process. For details on all of the attributes that can be 
 require 'cronitor'
 Cronitor.api_key = 'api_key_123'
 
-# read config file and set credentials (if included).
+# read config file.
 Cronitor.read_config('./cronitor.yaml')
 
 # sync config file's monitors to Cronitor.

--- a/README.md
+++ b/README.md
@@ -181,6 +181,11 @@ require 'cronitor'
 Cronitor.api_key = 'apiKey123'
 Cronitor.api_version = '2020-10-01'
 Cronitor.environment = 'cluster_1_prod'
+
+Cronitor.timeout = 20 # defaults to 10 can also be set with ENV['CRONITOR_TIMEOUT']
+Cronitor.logger = nil # defaults to Logger.new($stdout)
+# faster timeout for potentially more time sensitive call
+Cronitor.ping_timeout = 10 # defaults to 5 can also be set with ENV['CRONITOR_PING_TIMEOUT']
 ```
 
 ## Contributing

--- a/lib/cronitor.rb
+++ b/lib/cronitor.rb
@@ -51,8 +51,9 @@ module Cronitor
 
   def self.apply_config(rollback: false)
     conf = read_config(output: true)
-    # allow a significantly longer timeout on requests that are sending full yaml config
-    monitors = Monitor.put(monitors: conf.fetch('monitors', []), rollback: rollback, timeout: 30)
+    # allow a significantly longer timeout on requests that are sending full yaml config. min 30 seconds.
+    timeout = Cronitor.timeout < 30 ? 30 : Cronitor.timeout
+    monitors = Monitor.put(monitors: conf.fetch('monitors', []), rollback: rollback, timeout: timeout)
     puts("#{monitors.length} monitors #{rollback ? 'validated' : 'synced to Cronitor'}.")
   rescue ValidationError => e
     Cronitor.logger&.error(e)

--- a/lib/cronitor.rb
+++ b/lib/cronitor.rb
@@ -13,7 +13,7 @@ require 'cronitor/version'
 require 'cronitor/monitor'
 
 module Cronitor
-  def self.read_config(path = nil, output: false)
+  def self.read_config(path = nil)
     Cronitor.config = path || Cronitor.config
     unless Cronitor.config
       raise ConfigurationError.new(
@@ -26,35 +26,21 @@ module Cronitor
     conf.each do |k, _v|
       raise ConfigurationError.new("Invalid configuration variable: #{k}") unless Cronitor::YAML_KEYS.include?(k)
     end
-
-    return unless output
-
-    monitors = []
-    Cronitor::MONITOR_TYPES.each do |t|
-      plural_t = "#{t}s"
-      to_parse = conf[t] || conf[plural_t] || nil
-      next unless to_parse
-
-      unless to_parse.is_a?(Hash)
-        raise ConfigurationError.new('A Hash with keys corresponding to monitor keys is expected.')
-      end
-
-      to_parse.each do |key, m|
-        m['key'] = key
-        m['type'] = t
-        monitors << m
-      end
-    end
-    conf['monitors'] = monitors
     conf
   end
 
   def self.apply_config(rollback: false)
-    conf = read_config(output: true)
+    conf = read_config
     # allow a significantly longer timeout on requests that are sending full yaml config. min 30 seconds.
     timeout = Cronitor.timeout < 30 ? 30 : Cronitor.timeout
-    monitors = Monitor.put(monitors: conf.fetch('monitors', []), rollback: rollback, timeout: timeout)
-    puts("#{monitors.length} monitors #{rollback ? 'validated' : 'synced to Cronitor'}.")
+    monitors = Monitor.put(monitors: conf, format: Cronitor::Monitor::Formats::YAML, rollback: rollback,
+                           timeout: timeout)
+    count = 0
+    # step through the different monitor types and count up all the returned configurations
+    Cronitor::YAML_KEYS.each do |k|
+      count += (monitors[k]&.count || 0)
+    end
+    puts("#{count} monitors #{rollback ? 'validated' : 'synced to Cronitor'}.")
   rescue ValidationError => e
     Cronitor.logger&.error(e)
   end

--- a/lib/cronitor.rb
+++ b/lib/cronitor.rb
@@ -55,7 +55,7 @@ module Cronitor
     monitors = Monitor.put(monitors: conf.fetch('monitors', []), rollback: rollback, timeout: 30)
     puts("#{monitors.length} monitors #{rollback ? 'validated' : 'synced to Cronitor'}.")
   rescue ValidationError => e
-    Cronitor.logger.error(e)
+    Cronitor.logger&.error(e)
   end
 
   def self.validate_config

--- a/lib/cronitor.rb
+++ b/lib/cronitor.rb
@@ -27,10 +27,6 @@ module Cronitor
       raise ConfigurationError.new("Invalid configuration variable: #{k}") unless Cronitor::YAML_KEYS.include?(k)
     end
 
-    Cronitor.api_key     = conf[:api_key] if conf[:api_key]
-    Cronitor.api_version = conf[:api_version] if conf[:api_version]
-    Cronitor.environment = conf[:environment] if conf[:environment]
-
     return unless output
 
     monitors = []

--- a/lib/cronitor/config.rb
+++ b/lib/cronitor/config.rb
@@ -1,15 +1,12 @@
 # frozen_string_literal: true
 
 module Cronitor
-  TYPE_JOB = 'job'
-  TYPE_HEARTBEAT = 'heartbeat'
-  TYPE_CHECK = 'check'
-  MONITOR_TYPES = [TYPE_JOB, TYPE_HEARTBEAT, TYPE_CHECK].freeze
-  YAML_KEYS = %w[
-    api_key
-    api_version
-    environment
-  ] + MONITOR_TYPES.map { |t| "#{t}s" }
+  MONITOR_TYPES = [
+    TYPE_JOB = 'job',
+    TYPE_HEARTBEAT = 'heartbeat',
+    TYPE_CHECK = 'check',
+  ].freeze
+  YAML_KEYS = MONITOR_TYPES.map { |t| "#{t}s" }
 
   class << self
     attr_accessor :api_key, :api_version, :environment, :logger, :config, :_headers

--- a/lib/cronitor/config.rb
+++ b/lib/cronitor/config.rb
@@ -9,24 +9,19 @@ module Cronitor
   YAML_KEYS = MONITOR_TYPES.map { |t| "#{t}s" }
 
   class << self
-    attr_accessor :api_key, :api_version, :environment, :logger, :config, :timeout, :ping_timeout, :_headers
+    attr_accessor :api_key, :api_version, :environment, :logger, :config, :timeout, :ping_timeout
 
     def configure(&block)
       block.call(self)
     end
   end
 
-  self.api_key = ENV['CRONITOR_API_KEY']
-  self.api_version = ENV['CRONITOR_API_VERSION']
-  self.environment = ENV['CRONITOR_ENVIRONMENT']
-  self.timeout = ENV['CRONITOR_TIMEOUT'] || 10
-  self.ping_timeout = ENV['CRONITOR_PING_TIMEOUT'] || 5
-  self.config = ENV['CRONITOR_CONFIG']
+  self.api_key = ENV.fetch('CRONITOR_API_KEY', nil)
+  self.api_version = ENV.fetch('CRONITOR_API_VERSION', nil)
+  self.environment = ENV.fetch('CRONITOR_ENVIRONMENT', nil)
+  self.timeout = ENV.fetch('CRONITOR_TIMEOUT', nil) || 10
+  self.ping_timeout = ENV.fetch('CRONITOR_PING_TIMEOUT', nil) || 5
+  self.config = ENV.fetch('CRONITOR_CONFIG', nil)
   self.logger = Logger.new($stdout)
   logger.level = Logger::INFO
-  self._headers = {
-    'Content-Type': 'application/json',
-    'User-Agent': 'cronitor-ruby',
-    'Cronitor-Version': Cronitor.api_version
-  }
 end

--- a/lib/cronitor/config.rb
+++ b/lib/cronitor/config.rb
@@ -4,12 +4,12 @@ module Cronitor
   MONITOR_TYPES = [
     TYPE_JOB = 'job',
     TYPE_HEARTBEAT = 'heartbeat',
-    TYPE_CHECK = 'check',
+    TYPE_CHECK = 'check'
   ].freeze
   YAML_KEYS = MONITOR_TYPES.map { |t| "#{t}s" }
 
   class << self
-    attr_accessor :api_key, :api_version, :environment, :logger, :config, :_headers
+    attr_accessor :api_key, :api_version, :environment, :logger, :config, :timeout, :ping_timeout, :_headers
 
     def configure(&block)
       block.call(self)
@@ -19,6 +19,8 @@ module Cronitor
   self.api_key = ENV['CRONITOR_API_KEY']
   self.api_version = ENV['CRONITOR_API_VERSION']
   self.environment = ENV['CRONITOR_ENVIRONMENT']
+  self.timeout = ENV['CRONITOR_TIMEOUT'] || 10
+  self.ping_timeout = ENV['CRONITOR_PING_TIMEOUT'] || 5
   self.config = ENV['CRONITOR_CONFIG']
   self.logger = Logger.new($stdout)
   logger.level = Logger::INFO

--- a/lib/cronitor/monitor.rb
+++ b/lib/cronitor/monitor.rb
@@ -23,7 +23,7 @@ module Cronitor
           rollback: rollback
         }.to_json,
         headers: Cronitor._headers,
-        timeout: opts[:timeout] || 10
+        timeout: opts[:timeout] || Cronitor.timeout
       )
 
       case resp.code
@@ -47,7 +47,7 @@ module Cronitor
     def self.delete(key)
       resp = HTTParty.delete(
         "#{Cronitor.monitor_api_url}/#{key}",
-        timeout: 10,
+        timeout: Cronitor.timeout,
         basic_auth: {
           username: Cronitor.api_key,
           password: ''
@@ -92,7 +92,7 @@ module Cronitor
         response = HTTParty.get(
           ping_url,
           query: clean_params(params),
-          timeout: 5,
+          timeout: Cronitor.ping_timeout,
           headers: Cronitor._headers,
           query_string_normalizer: lambda do |query|
             query.compact!
@@ -131,7 +131,7 @@ module Cronitor
 
       resp = HTTParty.get(
         pause_url,
-        timeout: 5,
+        timeout: Cronitor.timeout,
         headers: Cronitor._headers,
         basic_auth: {
           username: api_key,
@@ -168,7 +168,7 @@ module Cronitor
         return
       end
 
-      HTTParty.get(monitor_api_url, timeout: 10, headers: Cronitor._headers, format: :json)
+      HTTParty.get(monitor_api_url, timeout: Cronitor.timeout, headers: Cronitor._headers, format: :json)
     end
 
     def clean_params(params)

--- a/lib/cronitor/monitor.rb
+++ b/lib/cronitor/monitor.rb
@@ -55,7 +55,7 @@ module Cronitor
         headers: Cronitor._headers
       )
       if resp.code != 204
-        Cronitor.logger.error("Error deleting monitor: #{key}")
+        Cronitor.logger&.error("Error deleting monitor: #{key}")
         return false
       end
       true
@@ -81,7 +81,7 @@ module Cronitor
     def ping(params = {})
       retry_count = params[:retry_count] || 0
       if api_key.nil?
-        Cronitor.logger.error('No API key detected. Set Cronitor.api_key or initialize Monitor with an api_key:')
+        Cronitor.logger&.error('No API key detected. Set Cronitor.api_key or initialize Monitor with an api_key:')
         return false
       end
 
@@ -106,13 +106,13 @@ module Cronitor
         )
 
         if response.code != 200
-          Cronitor.logger.error("Cronitor Telemetry Error: #{response.code}")
+          Cronitor.logger&.error("Cronitor Telemetry Error: #{response.code}")
           return false
         end
         true
       rescue StandardError => e
         # rescue instances of StandardError i.e. Timeout::Error, SocketError, etc
-        Cronitor.logger.error("Cronitor Telemetry Error: #{e}")
+        Cronitor.logger&.error("Cronitor Telemetry Error: #{e}")
         return false if retry_count >= Monitor::PING_RETRY_THRESHOLD
 
         # apply a backoff before sending the next ping
@@ -162,7 +162,7 @@ module Cronitor
 
     def fetch
       unless api_key
-        Cronitor.logger.error(
+        Cronitor.logger&.error(
           'No API key detected. Set Cronitor.api_key or initialize Monitor with the api_key kwarg'
         )
         return

--- a/lib/cronitor/monitor.rb
+++ b/lib/cronitor/monitor.rb
@@ -6,41 +6,74 @@ module Cronitor
 
     PING_RETRY_THRESHOLD = 5
 
+    module Formats
+      ALL = [
+        JSON = 'json',
+        YAML = 'yaml'
+      ].freeze
+    end
+
+    module Headers
+      JSON = {
+        'Content-Type': 'application/json',
+        'User-Agent': "cronitor-ruby-#{Cronitor::VERSION}",
+        'Cronitor-Version': Cronitor.api_version
+      }.freeze
+      YAML = JSON.merge({
+                          'Content-Type': 'application/yaml'
+                        })
+    end
+
     def self.put(opts = {})
       rollback = opts[:rollback] || false
       opts.delete(:rollback)
 
       monitors = opts[:monitors] || [opts]
 
+      if opts[:format] == Cronitor::Monitor::Formats::YAML
+        url = "#{Cronitor.monitor_api_url}.yaml"
+        monitors['rollback'] = true if rollback
+        body = YAML.dump(monitors)
+        headers = Cronitor::Monitor::Headers::YAML
+      else
+        url = Cronitor.monitor_api_url
+        body = {
+          monitors: monitors,
+          rollback: rollback
+        }.to_json
+        headers = Cronitor::Monitor::Headers::JSON
+      end
+
       resp = HTTParty.put(
-        Cronitor.monitor_api_url,
+        url,
         basic_auth: {
           username: Cronitor.api_key,
           password: ''
         },
-        body: {
-          monitors: monitors,
-          rollback: rollback
-        }.to_json,
-        headers: Cronitor._headers,
+        body: body,
+        headers: headers,
         timeout: opts[:timeout] || Cronitor.timeout
       )
 
       case resp.code
       when 200
-        out = []
-        data = JSON.parse(resp.body)
+        if opts[:format] == Cronitor::Monitor::Formats::YAML
+          YAML.safe_load(resp.body)
+        else
+          out = []
+          data = JSON.parse(resp.body)
 
-        (data['monitors'] || []).each do |md|
-          m = Monitor.new(md['key'])
-          m.data = Cronitor.symbolize_keys(md)
-          out << m
+          (data['monitors'] || []).each do |md|
+            m = Monitor.new(md['key'])
+            m.data = Cronitor.symbolize_keys(md)
+            out << m
+          end
+          out.length == 1 ? out[0] : out
         end
-        out.length == 1 ? out[0] : out
       when 400
         raise ValidationError.new(resp.body)
       else
-        raise Error.new("Error connecting to Cronitor: #{resp.code}")
+        raise Error.new("Error connecting to Cronitor: #{resp.code}\n #{resp.body}")
       end
     end
 
@@ -52,7 +85,7 @@ module Cronitor
           username: Cronitor.api_key,
           password: ''
         },
-        headers: Cronitor._headers
+        headers: Cronitor::Monitor::Headers::JSON
       )
       if resp.code != 204
         Cronitor.logger&.error("Error deleting monitor: #{key}")
@@ -93,7 +126,7 @@ module Cronitor
           ping_url,
           query: clean_params(params),
           timeout: Cronitor.ping_timeout,
-          headers: Cronitor._headers,
+          headers: Cronitor::Monitor::Headers::JSON,
           query_string_normalizer: lambda do |query|
             query.compact!
             metrics = query[:metric]
@@ -132,7 +165,7 @@ module Cronitor
       resp = HTTParty.get(
         pause_url,
         timeout: Cronitor.timeout,
-        headers: Cronitor._headers,
+        headers: Cronitor::Monitor::Headers::JSON,
         basic_auth: {
           username: api_key,
           password: ''
@@ -168,7 +201,7 @@ module Cronitor
         return
       end
 
-      HTTParty.get(monitor_api_url, timeout: Cronitor.timeout, headers: Cronitor._headers, format: :json)
+      HTTParty.get(monitor_api_url, timeout: Cronitor.timeout, headers: Cronitor::Monitor::Headers::JSON, format: :json)
     end
 
     def clean_params(params)

--- a/lib/cronitor/version.rb
+++ b/lib/cronitor/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Cronitor
-  VERSION = '4.1.2'
+  VERSION = '5.0.0'
 end

--- a/spec/support/bad_config.yaml
+++ b/spec/support/bad_config.yaml
@@ -1,0 +1,22 @@
+jobs:
+    replenishment-report:
+        schedule: '0 * * * *'
+    data-warehouse-exports:
+        schedule: '0 0 * * *'
+    welcome-email:
+        schedule: 'every 10 minutes'
+
+checkers:
+    cronitor-homepage:
+        request:
+            url: 'https://cronitor.io'
+        assertions:
+            - 'response.time < 2s'
+
+heartbeats:
+    production-deploy:
+        notify:
+            alerts:
+                - default
+            events:
+                complete: true


### PR DESCRIPTION
* remove api key support from yaml config
* it's not a good practice to encourage storage of credentials in a config file that will likely end up in version control
* use safe navigation operator on logging calls
* allow the user to config the network timeout
* bump version to 4.1.3
* update README documentation to reflect configuration option
* add version number to the user agent string
* remove redundant conversion of YAML to JSON
* use YAML endpoint when available