### PR TITLE
Add Ruby 3.1 and 3.2 to CI.  Update checkout action versions to v3.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,15 +15,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Ruby 2.7
-        uses: actions/setup-ruby@v1
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.x
+          ruby-version: 2.7
+          bundler-cache: true
       - name: Build and test with Rake
         run: |
-          gem install bundler
-          bundle install --jobs 4 --retry 3
           bundle exec rake release
         with:
           api_key: ${{secrets.RUBYGEMS_API_KEY}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,18 +37,18 @@ jobs:
         ruby:
           - '2.7'
           - '3.0'
+          - '3.1'
+          - '3.2'
 
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Ruby 2.7
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - name: Build and test with Rake
         run: |
-          gem install bundler
-          bundle install --jobs 4 --retry 3
           bundle exec rake


### PR DESCRIPTION
Also switched the publish action to use the supported `ruby/setup-ruby` action.

Runs green on my fork.