### PR TITLE
Extract endpoints into config file

### DIFF
--- a/lib/cronitor.rb
+++ b/lib/cronitor.rb
@@ -64,7 +64,7 @@ module Cronitor
   end
 
   def self.monitor_api_url
-    'https://cronitor.io/api/monitors'
+    "#{Cronitor.monitor_endpoint}/api/monitors"
   end
 end
 

--- a/lib/cronitor.rb
+++ b/lib/cronitor.rb
@@ -64,7 +64,7 @@ module Cronitor
   end
 
   def self.monitor_api_url
-    "#{Cronitor.monitor_endpoint}/api/monitors"
+    "#{Cronitor.monitor_url}/api/monitors"
   end
 end
 

--- a/lib/cronitor/config.rb
+++ b/lib/cronitor/config.rb
@@ -23,8 +23,8 @@ module Cronitor
   self.ping_timeout = ENV.fetch('CRONITOR_PING_TIMEOUT', nil) || 5
   self.config = ENV.fetch('CRONITOR_CONFIG', nil)
   self.auto_discover_sidekiq = ENV.fetch('CRONITOR_AUTO_DISCOVER_SIDEKIQ', 'true').casecmp('true').zero? # https://github.com/cronitorio/cronitor-sidekiq
-  self.ping_url = ENV.fetch('CRONITOR_ping_url', 'https://cronitor.link')
-  self.monitor_url = ENV.fetch('CRONITOR_monitor_url', 'https://cronitor.io')
+  self.ping_url = ENV.fetch('CRONITOR_PING_URL', 'https://cronitor.link')
+  self.monitor_url = ENV.fetch('CRONITOR_MONITOR_URL', 'https://cronitor.io')
   self.logger = Logger.new($stdout)
   logger.level = Logger::INFO
 end

--- a/lib/cronitor/config.rb
+++ b/lib/cronitor/config.rb
@@ -20,7 +20,7 @@ module Cronitor
     end
 
     def default_monitor_url
-      ENV.fetch('CRONITOR_PING_URL', 'https://cronitor.link')
+      ENV.fetch('CRONITOR_MONITOR_URL', 'https://cronitor.io')
     end
   end
 

--- a/lib/cronitor/config.rb
+++ b/lib/cronitor/config.rb
@@ -9,7 +9,7 @@ module Cronitor
   YAML_KEYS = MONITOR_TYPES.map { |t| "#{t}s" }
 
   class << self
-    attr_accessor :api_key, :api_version, :environment, :logger, :config, :timeout, :ping_timeout, :auto_discover_sidekiq
+    attr_accessor :api_key, :api_version, :environment, :logger, :config, :timeout, :ping_timeout, :auto_discover_sidekiq, :ping_endpoint, :monitor_endpoint
 
     def configure(&block)
       block.call(self)
@@ -23,6 +23,8 @@ module Cronitor
   self.ping_timeout = ENV.fetch('CRONITOR_PING_TIMEOUT', nil) || 5
   self.config = ENV.fetch('CRONITOR_CONFIG', nil)
   self.auto_discover_sidekiq = ENV.fetch('CRONITOR_AUTO_DISCOVER_SIDEKIQ', 'true').casecmp('true').zero? # https://github.com/cronitorio/cronitor-sidekiq
+  self.ping_endpoint = ENV.fetch('CRONITOR_PING_ENDPOINT', 'https://cronitor.link')
+  self.monitor_endpoint = ENV.fetch('CRONITOR_MONITOR_ENDPOINT', 'https://cronitor.io')
   self.logger = Logger.new($stdout)
   logger.level = Logger::INFO
 end

--- a/lib/cronitor/config.rb
+++ b/lib/cronitor/config.rb
@@ -14,6 +14,14 @@ module Cronitor
     def configure(&block)
       block.call(self)
     end
+
+    def default_ping_url
+      ENV.fetch('CRONITOR_PING_URL', 'https://cronitor.link')
+    end
+
+    def default_monitor_url
+      ENV.fetch('CRONITOR_PING_URL', 'https://cronitor.link')
+    end
   end
 
   self.api_key = ENV.fetch('CRONITOR_API_KEY', nil)
@@ -23,8 +31,8 @@ module Cronitor
   self.ping_timeout = ENV.fetch('CRONITOR_PING_TIMEOUT', nil) || 5
   self.config = ENV.fetch('CRONITOR_CONFIG', nil)
   self.auto_discover_sidekiq = ENV.fetch('CRONITOR_AUTO_DISCOVER_SIDEKIQ', 'true').casecmp('true').zero? # https://github.com/cronitorio/cronitor-sidekiq
-  self.ping_url = ENV.fetch('CRONITOR_PING_URL', 'https://cronitor.link')
-  self.monitor_url = ENV.fetch('CRONITOR_MONITOR_URL', 'https://cronitor.io')
+  self.ping_url = default_ping_url
+  self.monitor_url = default_monitor_url
   self.logger = Logger.new($stdout)
   logger.level = Logger::INFO
 end

--- a/lib/cronitor/config.rb
+++ b/lib/cronitor/config.rb
@@ -9,7 +9,7 @@ module Cronitor
   YAML_KEYS = MONITOR_TYPES.map { |t| "#{t}s" }
 
   class << self
-    attr_accessor :api_key, :api_version, :environment, :logger, :config, :timeout, :ping_timeout, :auto_discover_sidekiq, :ping_endpoint, :monitor_endpoint
+    attr_accessor :api_key, :api_version, :environment, :logger, :config, :timeout, :ping_timeout, :auto_discover_sidekiq, :ping_url, :monitor_url
 
     def configure(&block)
       block.call(self)
@@ -23,8 +23,8 @@ module Cronitor
   self.ping_timeout = ENV.fetch('CRONITOR_PING_TIMEOUT', nil) || 5
   self.config = ENV.fetch('CRONITOR_CONFIG', nil)
   self.auto_discover_sidekiq = ENV.fetch('CRONITOR_AUTO_DISCOVER_SIDEKIQ', 'true').casecmp('true').zero? # https://github.com/cronitorio/cronitor-sidekiq
-  self.ping_endpoint = ENV.fetch('CRONITOR_PING_ENDPOINT', 'https://cronitor.link')
-  self.monitor_endpoint = ENV.fetch('CRONITOR_MONITOR_ENDPOINT', 'https://cronitor.io')
+  self.ping_url = ENV.fetch('CRONITOR_ping_url', 'https://cronitor.link')
+  self.monitor_url = ENV.fetch('CRONITOR_monitor_url', 'https://cronitor.io')
   self.logger = Logger.new($stdout)
   logger.level = Logger::INFO
 end

--- a/lib/cronitor/monitor.rb
+++ b/lib/cronitor/monitor.rb
@@ -180,7 +180,7 @@ module Cronitor
     end
 
     def ping_api_url
-      "https://cronitor.link/p/#{api_key}/#{key}"
+      "#{Cronitor.ping_endpoint}/p/#{api_key}/#{key}"
     end
 
     def fallback_ping_api_url

--- a/lib/cronitor/monitor.rb
+++ b/lib/cronitor/monitor.rb
@@ -180,7 +180,7 @@ module Cronitor
     end
 
     def ping_api_url
-      "#{Cronitor.ping_endpoint}/p/#{api_key}/#{key}"
+      "#{Cronitor.ping_url}/p/#{api_key}/#{key}"
     end
 
     def fallback_ping_api_url

--- a/spec/cronitor_spec.rb
+++ b/spec/cronitor_spec.rb
@@ -37,6 +37,31 @@ RSpec.describe Cronitor do
       expect(Cronitor.ping_url).to eq('https://foo.com')
       expect(Cronitor.monitor_url).to eq('https://bar.com')
     end
+
+    context 'when no CRONITOR_PING_URL or CRONITOR_MONITOR_URL ENV variables are set' do
+      it 'returns the default Cronitor URLs' do
+        expect(Cronitor.ping_url).to eq('https://cronitor.link')
+        expect(Cronitor.monitor_url).to eq('ttps://cronitor.io')
+      end
+    end
+
+    context 'when custom CRONITOR_PING_URL and CRONITOR_MONITOR_URL ENV variables are set' do
+      let(:env_vars) do
+        ENV.to_hash.merge(
+          'CRONITOR_PING_URL' => 'https://ping.com',
+          'CRONITOR_MONITOR_URL' => 'https://monitor.com'
+        )
+      end
+
+      before do
+        stub_const('ENV', env_vars)
+      end
+
+      it 'returns the custom Cronitor URLs' do
+        expect(Cronitor.ping_url).to eq('https://ping.com')
+        expect(Cronitor.monitor_url).to eq('https://monitor.com')
+      end
+    end
   end
 
   describe 'YAML configuration' do

--- a/spec/cronitor_spec.rb
+++ b/spec/cronitor_spec.rb
@@ -22,26 +22,28 @@ MONITOR_2[:key] = 'another-test-key'
 RSpec.describe Cronitor do
 
   describe '#configure' do
-    it 'sets the api_key, api_version, env, ping_url and monitor_url' do
+    it 'sets the api_key, api_version, and env' do
       Cronitor.configure do |cronitor|
         cronitor.api_key = 'foo'
         cronitor.api_version = 'bar'
         cronitor.environment = 'baz'
-        cronitor.ping_url = 'https://foo.com'
-        cronitor.monitor_url = 'https://bar.com'
       end
 
       expect(Cronitor.api_key).to eq('foo')
       expect(Cronitor.api_version).to eq('bar')
       expect(Cronitor.environment).to eq('baz')
-      expect(Cronitor.ping_url).to eq('https://foo.com')
-      expect(Cronitor.monitor_url).to eq('https://bar.com')
     end
+  end
 
-    context 'when no CRONITOR_PING_URL or CRONITOR_MONITOR_URL ENV variables are set' do
-      it 'returns the default Cronitor URLs' do
-        expect(Cronitor.ping_url).to eq('https://cronitor.link')
-        expect(Cronitor.monitor_url).to eq('ttps://cronitor.io')
+  describe '#ping_url and #monitor_url' do
+    let(:env_vars) { ENV }
+
+    before do
+      stub_const('ENV', env_vars)
+      # We need to reset the ping_url and monitor_url since the previous spec sets them globally
+      Cronitor.configure do |cronitor|
+        cronitor.ping_url = cronitor.default_ping_url
+        cronitor.monitor_url = cronitor.default_monitor_url
       end
     end
 
@@ -53,13 +55,16 @@ RSpec.describe Cronitor do
         )
       end
 
-      before do
-        stub_const('ENV', env_vars)
-      end
-
       it 'returns the custom Cronitor URLs' do
         expect(Cronitor.ping_url).to eq('https://ping.com')
         expect(Cronitor.monitor_url).to eq('https://monitor.com')
+      end
+    end
+
+    context 'when no CRONITOR_PING_URL or CRONITOR_MONITOR_URL ENV variables are set' do
+      it 'returns the default Cronitor URLs' do
+        expect(Cronitor.ping_url).to eq('https://cronitor.link')
+        expect(Cronitor.monitor_url).to eq('https://cronitor.io')
       end
     end
   end

--- a/spec/cronitor_spec.rb
+++ b/spec/cronitor_spec.rb
@@ -22,16 +22,20 @@ MONITOR_2[:key] = 'another-test-key'
 RSpec.describe Cronitor do
 
   describe '#configure' do
-    it 'sets the api_key, api_version, and env' do
+    it 'sets the api_key, api_version, env, ping_url and monitor_url' do
       Cronitor.configure do |cronitor|
         cronitor.api_key = 'foo'
         cronitor.api_version = 'bar'
         cronitor.environment = 'baz'
+        cronitor.ping_url = 'https://foo.com'
+        cronitor.monitor_url = 'https://bar.com'
       end
 
       expect(Cronitor.api_key).to eq('foo')
       expect(Cronitor.api_version).to eq('bar')
       expect(Cronitor.environment).to eq('baz')
+      expect(Cronitor.ping_url).to eq('https://foo.com')
+      expect(Cronitor.monitor_url).to eq('https://bar.com')
     end
   end
 


### PR DESCRIPTION
There are two places in the SDK which reference the Cronitor API*:
- `Cronitor#ping_api_url` which points to `https://cronitor.link`
- `Cronitor#monitor_api_url` which points to `https://cronitor.io`

These endpoints are currently hardcoded into the SDK.

This PR will extract them into the config file and allow them to be read from ENV variables:
- `Cronitor#ping_url` will read from `ENV['CRONITOR_PING_URL']` and use `https://cronitor.link` as backup
- `Cronitor#monitor_url` will read from `ENV['CRONITOR_MONITOR_URL']` and use `https://cronitor.io` as a backup.

The behaviour will not change for existing users. But it will allow for customising the endpoints by others (and me 😄)

*There is a third, `Cronitor#fallback_ping_api_url` which I have not touched since I can't imagine anyone wanting to change it