### PR TITLE
Authenticate when fetching monitors

### DIFF
--- a/lib/cronitor/monitor.rb
+++ b/lib/cronitor/monitor.rb
@@ -201,7 +201,16 @@ module Cronitor
         return
       end
 
-      HTTParty.get(monitor_api_url, timeout: Cronitor.timeout, headers: Cronitor::Monitor::Headers::JSON, format: :json)
+      HTTParty.get(
+        monitor_api_url,
+        basic_auth: {
+          username: api_key,
+          password: ''
+        },
+        timeout: Cronitor.timeout,
+        headers: Cronitor::Monitor::Headers::JSON,
+        format: :json
+      )
     end
 
     def clean_params(params)

--- a/spec/cronitor_spec.rb
+++ b/spec/cronitor_spec.rb
@@ -242,6 +242,25 @@ RSpec.describe Cronitor do
         end
       end
     end
+
+    context '#data' do
+      it 'should fetch the monitor with cronitor api key' do
+        expect(HTTParty).to receive(:get).with("https://cronitor.io/api/monitors", hash_including(basic_auth: {username: Cronitor.api_key, password: ''})).and_return(
+          instance_double(HTTParty::Response, code: 200, body: MONITOR.to_json)
+        )
+        Cronitor::Monitor.new('test-job').data
+      end
+
+      context 'when monitor api key is provided' do
+        it 'should fetch the monitor with monitor api key' do
+          api_key = 'monitor_api_key'
+          expect(HTTParty).to receive(:get).with("https://cronitor.io/api/monitors", hash_including(basic_auth: {username: api_key, password: ''})).and_return(
+            instance_double(HTTParty::Response, code: 200, body: MONITOR.to_json)
+          )
+          Cronitor::Monitor.new('test-job', api_key: api_key).data
+        end
+      end
+    end
   end
 
   describe 'functional tests - ', type: 'functional' do


### PR DESCRIPTION
Adds authentication to the API request that fetches data for individual monitors (via Cronitor::Monitor#data). Currently no authentication is used and this method always returns an Unauthorized response. If an API key is set on the Cronitor::Monitor instance it will be used, otherwise `Cronitor.api_key` will be used.

**Before:**
```
Cronitor::Monitor.new("my-monitor").data
=> #<HTTParty::Response:0x28370 parsed_response={"detail"=>"Authentication credentials were not provided."}, @response=#<Net::HTTPUnauthorized 401 Unauthorized readbody=true>, @headers={"date"=>["Tue, 27 Aug 2024 20:12:07 GMT"], "content-type"=>["application/json"], "content-length"=>["58"], "connection"=>["close"], "server"=>["nginx/1.18.0 (Ubuntu)"], "www-authenticate"=>["bearer"], "vary"=>["Accept, Cookie"], "allow"=>["GET, PUT, DELETE, HEAD, OPTIONS"], "x-frame-options"=>["DENY"]}>
```

**After:**
```
Cronitor::Monitor.new("my-monitor").data
=> #<HTTParty::Response:0x28280 parsed_response={"attributes"=>{...}}, @response=#<Net::HTTPOK 200 OK readbody=true>, @headers={"date"=>["Tue, 27 Aug 2024 19:33:53 GMT"], "content-type"=>["application/json"], "content-length"=>["1159"], "connection"=>["close"], "server"=>["nginx/1.18.0 (Ubuntu)"], "vary"=>["Accept"], "allow"=>["GET, PUT, DELETE, HEAD, OPTIONS"], "x-frame-options"=>["DENY"]}>
```