### PR TITLE
Fix monitor delete method

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ monitor = Cronitor::Monitor.new('heartbeat-monitor')
 monitor.pause(24) # pause alerting for 24 hours
 monitor.unpause # alias for .pause(0)
 monitor.ok # manually reset to a passing state alias for monitor.ping({state: ok})
-monitor.delete # destroy the monitor
+Cronitor::Monitor.delete('heartbeat-monitor') # destroy the monitor
 ```
 
 ## Package Configuration

--- a/lib/cronitor/monitor.rb
+++ b/lib/cronitor/monitor.rb
@@ -5,6 +5,7 @@ module Cronitor
     attr_reader :key, :api_key, :api_version, :env
 
     PING_RETRY_THRESHOLD = 3
+    API_URL = 'https://cronitor.io/api/monitors'.freeze
 
     module Formats
       ALL = [
@@ -30,7 +31,7 @@ module Cronitor
       opts.delete(:rollback)
 
       monitors = opts[:monitors] || [opts]
-      url = "https://cronitor.io/api/monitors"
+      url = Cronitor::Monitor::API_URL
       if opts[:format] == Cronitor::Monitor::Formats::YAML
         url = "#{url}.yaml"
         monitors['rollback'] = true if rollback
@@ -79,7 +80,7 @@ module Cronitor
 
     def self.delete(key)
       resp = HTTParty.delete(
-        "#{Cronitor.monitor_api_url}/#{key}",
+        "#{Cronitor::Monitor::API_URL}/#{key}",
         timeout: Cronitor.timeout,
         basic_auth: {
           username: Cronitor.api_key,
@@ -158,7 +159,7 @@ module Cronitor
     end
 
     def pause(hours = nil)
-      pause_url = "#{monitor_api_url}/#{key}/pause"
+      pause_url = "#{Cronitor::Monitor::API_URL}/#{key}/pause"
       pause_url += "/#{hours}" unless hours.nil?
 
       resp = HTTParty.get(
@@ -186,11 +187,6 @@ module Cronitor
       "https://cronitor.io/p/#{api_key}/#{key}"
     end
 
-    def monitor_api_url
-      "https://cronitor.io/api/monitors"
-    end
-
-
     private
 
     def fetch
@@ -202,7 +198,7 @@ module Cronitor
       end
 
       HTTParty.get(
-        monitor_api_url,
+        Cronitor::Monitor::API_URL,
         basic_auth: {
           username: api_key,
           password: ''


### PR DESCRIPTION
`.delete` is a class method and `monitor_api_url` isn't defined on the class or the config, just on an instance of a monitor. I moved the API URL up to a constant and removed the instance method so that it can be utilized from a class or instance method.